### PR TITLE
Add ELK and Filebeat Observability Stack with Helm

### DIFF
--- a/observability/clean-up.sh
+++ b/observability/clean-up.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+NAMESPACE="elk-stack"
+
+helm list --short --namespace $NAMESPACE | xargs helm uninstall --namespace $NAMESPACE
+
+kubectl delete all --all -n=$NAMESPACE --force --grace-period=0
+kubectl delete ns $NAMESPACE --force --grace-period=0

--- a/observability/helm-elk-stack.sh
+++ b/observability/helm-elk-stack.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+NAMESPACE="elk-stack"
+VERSION="8.5.1"
+
+# add and update elastic repo
+helm repo add elastic https://helm.elastic.co
+helm repo update
+
+# components installation
+helm install filebeat elastic/filebeat \
+	--version $VERSION \
+	--namespace $NAMESPACE \
+	--create-namespace \
+	--replace \
+	-f values/filebeat.yaml
+
+helm install elasticsearch elastic/elasticsearch \
+	--version $VERSION \
+	--namespace $NAMESPACE \
+	--create-namespace \
+	--replace \
+	-f values/elasticsearch.yaml
+	
+helm install logstash elastic/logstash \
+	--version $VERSION \
+	--namespace $NAMESPACE \
+	--create-namespace \
+	--timeout=10m \
+	--replace \
+	-f values/logstash.yaml
+
+helm install kibana elastic/kibana \
+	--version $VERSION \
+	--namespace $NAMESPACE \
+	--create-namespace \
+	--replace \
+	-f values/kibana.yaml

--- a/observability/helm-elk-stack.sh
+++ b/observability/helm-elk-stack.sh
@@ -5,17 +5,31 @@ set -e
 NAMESPACE="elk-stack"
 VERSION="8.5.1"
 
-# add and update elastic repo
+echo "Add and Update Elastic repository"
 helm repo add elastic https://helm.elastic.co
 helm repo update
 
-# components installation
-helm install filebeat elastic/filebeat \
+echo "Stack Component Installation"
+helm install filebeat-kubelet elastic/filebeat \
 	--version $VERSION \
 	--namespace $NAMESPACE \
 	--create-namespace \
 	--replace \
-	-f values/filebeat.yaml
+	-f values/filebeat-kubelet-logs.yaml
+
+helm install filebeat-pods elastic/filebeat \
+	--version $VERSION \
+	--namespace $NAMESPACE \
+	--create-namespace \
+	--replace \
+	-f values/filebeat-pod-logs.yaml
+
+helm install filebeat-audit elastic/filebeat \
+	--version $VERSION \
+	--namespace $NAMESPACE \
+	--create-namespace \
+	--replace \
+	-f values/filebeat-audit-logs.yaml
 
 helm install elasticsearch elastic/elasticsearch \
 	--version $VERSION \
@@ -38,3 +52,5 @@ helm install kibana elastic/kibana \
 	--create-namespace \
 	--replace \
 	-f values/kibana.yaml
+
+echo "Finished"

--- a/observability/values/elasticsearch.yaml
+++ b/observability/values/elasticsearch.yaml
@@ -1,0 +1,14 @@
+# Elasticsearch values for local development
+resources:
+  requests:
+    cpu: "100m"
+    memory: "512Mi"
+  limits:
+    cpu: "1000m"
+    memory: "2Gi"
+
+# Disable resource-intensive features for dev
+esJavaOpts: "-Xmx512m -Xms512m"
+
+# Reduce JVM heap for development
+javaOpts: "-Xms512m -Xmx512m"

--- a/observability/values/filebeat-audit-logs.yaml
+++ b/observability/values/filebeat-audit-logs.yaml
@@ -1,17 +1,7 @@
+nameOverride: "filebeat-audit"
 filebeatConfig:
   filebeat.yml: |
     filebeat.inputs:
-    # Collect regular container logs
-    - type: container
-      paths:
-        - /var/log/containers/*.log
-      processors:
-        - add_kubernetes_metadata:
-            host: ${NODE_NAME}
-            matchers:
-            - logs_path:
-                logs_path: "/var/log/containers/"
-
     # Collect Kubernetes audit logs
     - type: log
       paths:
@@ -47,6 +37,10 @@ extraVolumeMounts:
   - name: audit-log
     mountPath: /var/log/kubernetes/audit/
     readOnly: true
+
+# Only run on control plane nodes
+nodeSelector:
+  node-role.kubernetes.io/control-plane: ""
 
 # Ensure Filebeat runs on master nodes to access audit logs
 tolerations:

--- a/observability/values/filebeat-kubelet-logs.yaml
+++ b/observability/values/filebeat-kubelet-logs.yaml
@@ -1,0 +1,37 @@
+# Filebeat for kubelet logs (runs on all nodes)
+nameOverride: "filebeat-kubelet"
+filebeatConfig:
+  filebeat.yml: |
+    filebeat.inputs:
+    # Collect kubelet logs from systemd journal
+    - type: journald
+      id: kubelet-logs
+      include_matches:
+        - _SYSTEMD_UNIT=kubelet.service
+      fields:
+        logtype: kubelet
+        service: kubelet
+      fields_under_root: true
+    
+    output.logstash:
+      hosts: ["logstash-logstash:5044"]
+    
+    logging.level: info
+
+# Mount systemd journal for kubelet logs
+daemonset:
+  extraVolumes:
+    - name: systemd-journal
+      hostPath:
+        path: /var/log/journal
+    - name: machine-id
+      hostPath:
+        path: /etc/machine-id
+        type: File
+  extraVolumeMounts:
+    - name: systemd-journal
+      mountPath: /var/log/journal
+      readOnly: true
+    - name: machine-id
+      mountPath: /etc/machine-id
+      readOnly: true

--- a/observability/values/filebeat-pod-logs.yaml
+++ b/observability/values/filebeat-pod-logs.yaml
@@ -1,0 +1,32 @@
+# Filebeat for pod logs (runs on all nodes)
+nameOverride: "filebeat-pods"
+filebeatConfig:
+  filebeat.yml: |
+    filebeat.inputs:
+    # Collect pod logs
+    - type: container
+      paths:
+        - /var/log/pods/*/*/*.log
+      processors:
+        - add_kubernetes_metadata:
+            host: ${NODE_NAME}
+            matchers:
+            - logs_path:
+                logs_path: "/var/log/pods/"
+      fields:
+        logtype: pod
+      fields_under_root: true
+    
+    output.logstash:
+      hosts: ["logstash-logstash:5044"]
+    
+    logging.level: info
+
+# Ensure Filebeat runs on master nodes to access audit logs
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/observability/values/filebeat.yaml
+++ b/observability/values/filebeat.yaml
@@ -1,0 +1,14 @@
+filebeatConfig:
+  filebeat.yml: |
+    filebeat.inputs:
+    - type: container
+      paths:
+        - /var/log/containers/*.log
+      processors:
+      - add_kubernetes_metadata:
+          host: ${NODE_NAME}
+          matchers:
+          - logs_path:
+              logs_path: "/var/log/containers/" 
+    output.logstash:
+      hosts: ["logstash-logstash:5044"]

--- a/observability/values/filebeat.yaml
+++ b/observability/values/filebeat.yaml
@@ -1,14 +1,58 @@
 filebeatConfig:
   filebeat.yml: |
     filebeat.inputs:
+    # Collect regular container logs
     - type: container
       paths:
         - /var/log/containers/*.log
       processors:
-      - add_kubernetes_metadata:
-          host: ${NODE_NAME}
-          matchers:
-          - logs_path:
-              logs_path: "/var/log/containers/" 
+        - add_kubernetes_metadata:
+            host: ${NODE_NAME}
+            matchers:
+            - logs_path:
+                logs_path: "/var/log/containers/"
+
+    # Collect Kubernetes audit logs
+    - type: log
+      paths:
+        - /var/log/audit.log
+      fields:
+        logtype: audit
+        component: kube-apiserver
+      fields_under_root: true
+      json.keys_under_root: true
+      json.add_error_key: true
+
+    # Output to Logstash
     output.logstash:
       hosts: ["logstash-logstash:5044"]
+
+    # Logging configuration
+    logging.level: info
+    logging.to_files: true
+    logging.files:
+      path: /var/log/filebeat
+      name: filebeat
+      keepfiles: 7
+      permissions: 0644
+
+# Mount audit log path
+extraVolumes:
+  - name: audit-log
+    hostPath:
+      path: /var/log/kubernetes/audit/
+      type: Directory
+
+extraVolumeMounts:
+  - name: audit-log
+    mountPath: /var/log/kubernetes/audit/
+    readOnly: true
+
+# Ensure Filebeat runs on master nodes to access audit logs
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/observability/values/kibana.yaml
+++ b/observability/values/kibana.yaml
@@ -1,0 +1,15 @@
+ingress:
+  enabled: true
+  className: "nginx"
+  pathtype: ImplementationSpecific
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: kibana.local
+      paths:
+        - path: /
+  #tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/observability/values/logstash.yaml
+++ b/observability/values/logstash.yaml
@@ -1,0 +1,23 @@
+logstashPipeline: 
+ logstash.conf: |
+   input {
+     beats {
+       port => 5044
+     }
+   }
+   output { elasticsearch { hosts => "http://elasticsearch-master:9200" } }
+
+
+service:
+  annotations: {}
+  type: ClusterIP
+  loadBalancerIP: ""
+  ports:
+    - name: beats
+      port: 5044
+      protocol: TCP
+      targetPort: 5044
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080


### PR DESCRIPTION
This PR aims to visualize logs using Elastic stack for the following components:

- [x] Kubelet.
- [x] Pods on worker node and on control plane: add toleration.
- [x] Audit logs: add toleration and node selector for the control planes. 